### PR TITLE
update GitHub Actions workflow to trigger on main branch and adjust r…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,13 +2,13 @@ name: Build and Release
 
 on:
   push:
-    tags:
-      - 'v*'  # Déclenche le workflow uniquement quand un tag version est poussé
+    branches:
+      - main  # Déclenche le workflow à chaque push sur la branche main
 
 jobs:
   build:
     name: Build and Release
-    runs-on: ubuntu-latest  # Utilise un runner Linux qui est plus léger et rapide
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -18,9 +18,9 @@ jobs:
         with:
           go-version: '1.21'
 
-      - name: Extract tag version
-        id: tag
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+      - name: Get short SHA
+        id: slug
+        run: echo "VERSION=$(echo ${GITHUB_SHA} | cut -c1-7)" >> $GITHUB_ENV
 
       - name: Install dependencies
         run: |
@@ -55,9 +55,10 @@ jobs:
         id: create_release
         uses: softprops/action-gh-release@v1
         with:
-          name: Release ${{ env.VERSION }}
+          name: Build ${{ env.VERSION }}
+          tag_name: build-${{ env.VERSION }}
           draft: false
-          prerelease: false
+          prerelease: true
           files: |
             SushiSyncCLI-windows-amd64.exe
             SushiSyncCLI-linux-amd64


### PR DESCRIPTION
This pull request includes significant changes to the GitHub Actions workflow for building and releasing the project. The modifications focus on triggering the workflow, versioning, and release naming conventions.

Triggering the workflow:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L5-R11): Changed the workflow trigger from tags to the `main` branch to initiate the workflow on every push to `main`.

Versioning:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L21-R23): Replaced the extraction of tag versions with the generation of a short SHA for versioning.

Release naming conventions:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L58-R61): Updated the release name to "Build" instead of "Release" and included a `tag_name` with a "build-" prefix. Also, changed the release to be marked as a prerelease