### PR TITLE
update GitHub Actions workflow to add permissions for creating releas…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main  # Déclenche le workflow à chaque push sur la branche main
 
+permissions:
+  contents: write  # Nécessaire pour créer des releases et pousser des tags
+
 jobs:
   build:
     name: Build and Release
@@ -18,8 +21,8 @@ jobs:
         with:
           go-version: '1.21'
 
-      - name: Get short SHA
-        id: slug
+      - name: Define version
+        id: version
         run: echo "VERSION=$(echo ${GITHUB_SHA} | cut -c1-7)" >> $GITHUB_ENV
 
       - name: Install dependencies


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow configuration for the release process. The changes primarily focus on adding necessary permissions and updating job steps for defining the version.

Workflow configuration updates:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R8-R10): Added `permissions` to allow writing contents, which is necessary for creating releases and pushing tags.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L21-R25): Updated job steps to replace "Get short SHA" with "Define version" for setting the version environment variable.